### PR TITLE
filtro de Fichas Orçamentárias por sessão + função alterada

### DIFF
--- a/app/Models/Lancamento.php
+++ b/app/Models/Lancamento.php
@@ -81,18 +81,18 @@ class Lancamento extends Model
                     ->withPivot(['percentual'])
                     ->withTimestamps();
     }
+    
+    public static function calculaSaldo($lancamento, $lancamento_last){
 
-    static function calculaSaldo($lancamento){
-
-        $lancamentos_conta = Lancamento::with('contas')->get();
-        $saldo  = 0.00;
-        foreach($lancamentos_conta as $calcula_saldo){
-            $saldo += $calcula_saldo->credito_raw - $calcula_saldo->debito_raw;
-            $calcula_saldo->saldo = $saldo;
-            $calcula_saldo->update();
+        if($lancamento_last){
+            $saldo = (float)str_replace(',','.',$lancamento_last->saldo);
+        } else {
+            $saldo = 0.00;
         }
-        return $saldo;
+        $saldo += $lancamento->credito_raw - $lancamento->debito_raw;
+        $lancamento->saldo = $saldo;
+        $lancamento->update();
+       
     }
-
     
 }

--- a/resources/views/ficorcamentarias/index.blade.php
+++ b/resources/views/ficorcamentarias/index.blade.php
@@ -7,6 +7,7 @@
     @include('messages.errors')
 <div class="card p-3">
     <h2><strong>Fichas Orçamentárias</strong></h2>
+    @include('partials.mostra_ano')
 </div>
 <br>    
 <div class="form-row">

--- a/resources/views/lancamentos/index_por_conta.blade.php
+++ b/resources/views/lancamentos/index_por_conta.blade.php
@@ -62,12 +62,12 @@
                     <td align="left">{{ $lancamento->ficorcamentaria_id }}</td>
                     <td>{{ $lancamento->receita }}</td>
                     @if($lancamento->debito != 0.00)
-                        <td>{{ $lancamento->debito }}</td>
+                        <td>{{ number_format((float)($lancamento->debito_raw * $lancamento->pivot->percentual/100),2, ',', '.') }}</td>
                     @else
                         <td>&nbsp;</td>
                     @endif
                     @if($lancamento->credito != 0.00)
-                        <td>{{ number_format($lancamento->credito_raw, 2, ',', '.') }}</td>
+                    <td>{{ number_format((float)($lancamento->credito_raw * $lancamento->pivot->percentual/100),2, ',', '.') }}</td>
                     @else
                         <td align="right">&nbsp;</td>
                     @endif


### PR DESCRIPTION
-> Anteriormente, o filtro das Fichas Orçamentárias era feito por movimento ativo (ano), agora é feito pela sessão, que pode ser alterada logo na parte superior do index, onde foi adicionado um calendário que muda a sessão, como na tela inicial do sistema;

-> Foi também alterado o modo de fazer o cálculo da função calculaSaldo, no model do Lançamento.
OBS: a verificação de existência da variável $lancamento_last é por conta de um erro que é apontado quando faz-se o primeiro Lançamento do sistema, momento em que não existe nenhum lançamento cadastrado.