### PR TITLE
Alterações faltantes

### DIFF
--- a/app/Http/Controllers/LancamentoController.php
+++ b/app/Http/Controllers/LancamentoController.php
@@ -10,6 +10,7 @@ use App\Models\TipoConta;
 use Illuminate\Http\Request;
 use App\Http\Requests\LancamentoRequest;
 use App\Http\Requests\PercentualRequest;
+use DB;
 use Redirect;
 
 class LancamentoController extends Controller
@@ -115,7 +116,7 @@ class LancamentoController extends Controller
 
         $lancamento['id'] = $lancamento->id;
         $lancamento_last = Lancamento::all()->last();
-        $contas_percentual[$request['contas']] = ['percentual' => $request['percentual']];
+        $contas_percentual[$request['contas']] = ['percentual' => str_replace(',', '.', $request['percentual'])];
         $lancamento->contas()->attach($contas_percentual);
         $calculaSaldoLancamento   = Lancamento::calculaSaldo($lancamento, $lancamento_last);
         $request->session()->flash('alert-success', 'Percentual cadastrado com sucesso!');
@@ -208,14 +209,15 @@ class LancamentoController extends Controller
         return redirect()->route('lancamentos.index');    
     }
 
-    /*
-    public function destroyPercentual(Lancamento $lancamento){
+    public function destroyPercentual(Lancamento $lancamento, Request $request){
         $this->authorize('Administrador');
         $lancamento->load('contas');
         foreach($lancamento->contas as $conta){
-           $conta->delete('percentual');
+            DB::table('conta_lancamento')->where('conta_id', $conta->id)
+                                         ->where('percentual', $request['percentual'])
+                                         ->delete();
         }
+        $request->session()->flash('alert-success', 'Percentual deletado com sucesso!');
         return back();    
     }
-    */
 }

--- a/app/Rules/PercentualRule.php
+++ b/app/Rules/PercentualRule.php
@@ -18,7 +18,7 @@ class PercentualRule implements Rule
     {
         $lancamento = Lancamento::where('id', $this->id)->first();
         $lancamento->load('contas');
-        $soma = $value;
+        $soma = str_replace(',', '.', $value);
         foreach($lancamento->contas as $conta){
             $soma += $conta->pivot->percentual;
             if($soma > 100) return false;

--- a/database/migrations/2022_11_18_143047_create_conta_lancamento_table.php
+++ b/database/migrations/2022_11_18_143047_create_conta_lancamento_table.php
@@ -14,8 +14,6 @@ class CreateContaLancamentoTable extends Migration
     public function up()
     {
         Schema::create('conta_lancamento', function (Blueprint $table) {
-            //$table->id();
-
             $table->unsignedBigInteger('conta_id');
             $table->foreign('conta_id')->references('id')
                   ->on('contas')->onDelete('cascade');
@@ -24,7 +22,7 @@ class CreateContaLancamentoTable extends Migration
             $table->foreign('lancamento_id')->references('id')
                     ->on('lancamentos')->onDelete('cascade');
 
-            $table->integer('percentual');
+            $table->string('percentual');
             $table->timestamps();
         });
     }

--- a/resources/views/lancamentos/show.blade.php
+++ b/resources/views/lancamentos/show.blade.php
@@ -93,6 +93,16 @@
                     <tr>
                         <td align="left">{{ $conta->nome }}</td>
                         <td>{{ $conta->pivot->percentual }}</td>
+                        @can('Administrador')
+                        <td align="center">
+                            <form method="post" role="form" action="/lancamentos/{{$lancamento->id}}/destroyPercentual" >
+                                @csrf
+                                <input name="_method" type="hidden" value="DELETE">
+                                <input type="hidden" name="percentual" value="{{ $conta->pivot->percentual }}">
+                                <button class="delete-item btn btn-danger" type="submit" onclick="return confirm('Deseja realmente excluir o Percentual?');">Excluir</button>
+                            </form>
+                        </td>
+                        @endcan
                     </tr>
                 @endforeach
             </tbody>


### PR DESCRIPTION
-> Foi consertado o método destroyPercentual, de forma que agora deleta apenas o percentual enviado e não todos;
-> Foi alterado o tipo do campo "percentual" na tabela pivot "conta_lancamento" para string, de forma que agora aceita símbolos e números, convertendo "," para "." no método onde é realizado o attach e na rule de validação.
